### PR TITLE
Fixes crash on setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cookiecutter
-click==3.3
+click==5.1


### PR DESCRIPTION
Removes click version from requirements because it was causing cookiecutter to crash.

```
error: click 3.3 is installed but click>=5.0 is required by set(['cookiecutter'])
```
