### PR TITLE
Change click version to the current version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cookiecutter
-click==5.1
+click==6.2
+


### PR DESCRIPTION
I don't know why you haven't changed to the new version yet, but I've been using `click==6.2` without crashing with `cookiecutter`.

So, here it is my attempt to contribution. :+1: 
